### PR TITLE
Run jobs in Docker to isolate from host system

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Code is sent as a POST request from the user's browser to the backend when they 
 
 ## Run Locally
 
+Make sure your system has Git, Node.js, and Docker installed then run the following commands:
+
 ```
 git clone https://github.com/rymaju/FundiesCollab.git
 npm install
 npm run build
 npm start
 ```
-
-Note that the backend uses `exec` to run commands, this may cause problems when running on Mac or Linux, but it should be easy to spot and fix.
 
 ## API
 


### PR DESCRIPTION
From now on, Docker is required on the system
to run FundiesCollab.

Previously, compile and run jobs were run on the
host system meaning it was trivial to remotely
execute anything on the host system.

This removes the remote code execution vulnerability
by running all jobs in an unprivileged container.

Because of this, Docker or some other OCI compatible
container runtime is required to run FundiesCollab.

I am assigning copyright ownership of these changes to @rymaju 

Signed-off-by: Gary Kim <gary@garykim.dev>